### PR TITLE
GitHub pages

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Deploy to github_pages
+on: [workflow_dispatch]
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install sphinx
+      run: |
+        pip install sphinx
+    - name: Git checkout and build sphinx docs
+      run: |
+        git config --global user.name "github-pages[bot]"
+        git config --global user.email "41898281+github-pages[bot]@users.noreply.github.com"
+        git fetch
+        git checkout github_pages
+        git checkout master
+        cd docs
+        make html
+    - name: push to gh-pages
+      run: |
+        git symbolic-ref HEAD refs/heads/github_pages
+        git reset --mixed github_pages
+        git add --all
+        git add -f docs/build
+        git commit -m "push sphinx build"
+        git push origin github_pages

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 *.so
 build
 .hypothesis/
+
+# macOS files
+*.DS_store
+

--- a/docs/.nojekyll
+++ b/docs/.nojekyll
@@ -1,0 +1,49 @@
+# Compiled python modules.
+*.pyc
+*.pyo
+*.pyd
+**/__pycache__
+
+# Setuptools distribution folder.
+/dist/
+
+# Python egg metadata, regenerated from source files by setuptools.
+/*.egg-info
+*.so
+build
+
+# Python jupyter notebooks
+examples/dask-worker-space
+examples/.ipynb_checkpoints
+
+# Data files
+*.pkl
+*.csv
+*.pqt
+data/*
+
+# Output files
+*.out
+
+# External
+**.DS_Store
+.idea/*
+.vscode/*
+*~
+
+# Unit test
+.pytest_cache/
+.hypothesis/
+
+# Pytest output files
+test-output.xml
+
+# Latex
+*.aux
+*.bbl
+*.blg
+*.brf
+*.log
+*.pdf
+*.synctex.gz
+*.toc

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; url=https://giotto-ai.github.io/giotto-ph/build/html/index.html">

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join('..','..')))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'giotto-ph'
+copyright = '2020, L2F SA'
+author = 'Julian Burella Perez'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.1'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['sphinx.ext.autodoc'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'classic'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,26 @@
+.. giotto-ph documentation master file, created by
+   sphinx-quickstart on Fri Jul  2 10:25:56 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to giotto-ph's documentation!
+=======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+.. automodule:: giotto_ph.python
+   :members:
+
+References
+----------
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
# High level description

This PR is to set-up the initial GitHub pages with the automatically generated docuemtantion

# What changes
 - The new workflow `deploy-github-pages.yml` allow to deploy, in one click, the documentation present on master
 - The documentation will then be available at https://giotto-ai.github.io/giotto-ph/
 - The docs folder, with the settings of sphinx. only the `docs/source/index.rst` file is to be modified in case we want to add new modules


# Remark

Do not delete the `github_pages` branch after this PR is merged!