### PR TITLE
Fix issue when computing PH with maxdim == 0

### DIFF
--- a/gph/python/test/test_ripser.py
+++ b/gph/python/test/test_ripser.py
@@ -321,8 +321,5 @@ def test_ph_maxdim_0():
     res_maxdim_0 = ripser(X, maxdim=0)['dgms'][0]
     res_maxdim_1 = ripser(X, maxdim=1)['dgms'][0]
 
-    # Verifies that the number of barcodes is the same
-    assert res_maxdim_0.shape[0] == res_maxdim_1.shape[0]
-
-    # Verifies if both computation have the same barcodes
+    # Verifies if both computations have the same barcodes
     assert_array_equal(res_maxdim_0, res_maxdim_1)

--- a/gph/python/test/test_ripser.py
+++ b/gph/python/test/test_ripser.py
@@ -315,6 +315,15 @@ def test_gens_order_vertices_higher_dimension():
 
 def test_ph_maxdim_0():
     """Regression test for issue #39, an issue was found when only computing
-    up to dimension 0. The test also compares the results of dimension 0"""
+    up to dimension 0. The test also compares the results of dimension 0
+    when maxdim=1 and maxdim=0"""
     X = np.array([[1., 2], [3, 4], [5, 0]])
-    ripser(X, maxdim=0)['dgms'][0]
+    res_maxdim_0 = ripser(X, maxdim=0)['dgms'][0]
+    res_maxdim_1 = ripser(X, maxdim=1)['dgms'][0]
+
+    # Verifies that the number of barcodes is the same
+    assert res_maxdim_0.shape[0] == res_maxdim_1.shape[0]
+
+    # Verifies if both computation have the same barcodes
+    for barcode in res_maxdim_0:
+        assert any(np.equal(barcode, res_maxdim_1).all(1))

--- a/gph/python/test/test_ripser.py
+++ b/gph/python/test/test_ripser.py
@@ -311,3 +311,10 @@ def test_gens_order_vertices_higher_dimension():
 
     assert len(gens_fin_dim2) == 1
     assert np.array_equal(gens_fin_dim2[0], np.array([1, 0, 5, 4]))
+
+
+def test_ph_maxdim_0():
+    """Regression test for issue #39, an issue was found when only computing
+    up to dimension 0. The test also compares the results of dimension 0"""
+    X = np.array([[1., 2], [3, 4], [5, 0]])
+    ripser(X, maxdim=0)['dgms'][0]

--- a/gph/python/test/test_ripser.py
+++ b/gph/python/test/test_ripser.py
@@ -3,7 +3,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats, integers, composite
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_array_equal
 from scipy.sparse import coo_matrix
 from scipy.spatial.distance import pdist, squareform
 
@@ -325,5 +325,4 @@ def test_ph_maxdim_0():
     assert res_maxdim_0.shape[0] == res_maxdim_1.shape[0]
 
     # Verifies if both computation have the same barcodes
-    for barcode in res_maxdim_0:
-        assert any(np.equal(barcode, res_maxdim_1).all(1))
+    assert_array_equal(res_maxdim_0, res_maxdim_1)

--- a/gph/src/ripser.h
+++ b/gph/src/ripser.h
@@ -985,6 +985,7 @@ public:
         std::vector<index_t> vertices_of_edge(2);
         columns_to_reduce.resize(edges.size());
         size_t i = 0;
+        const bool prepare_higher_dims = (dim_max > 0);
         value_t birth;
         diameter_index_t birth_vertex;
         for (auto e : edges) {
@@ -1014,7 +1015,8 @@ public:
                         }
                     }
                 }
-            } else if (get_index(get_zero_apparent_cofacet(e, 1)) == -1)
+            } else if (prepare_higher_dims &&
+                       get_index(get_zero_apparent_cofacet(e, 1)) == -1)
                 columns_to_reduce[i++] = e;
         }
         columns_to_reduce.resize(i);


### PR DESCRIPTION
This PR fixes issue #39 when computing persistent homology with the maximal dimension set to 0.

The issue was that in function `compute_dim_0`, we also prepare the columns to reduce for dimensions 1. But, when `maxdim=0`, we don't care about preparing those columns. Even worse was that `get_zero_apparent_cofacet(e, 1)` was assuming that we were always computing for `maxdim>0`.

This is now fixed by preparing the columns for dimension only if `maxdim > 0`.