### PR TITLE
[CPP] Remove zero diameter check for edges in 0-dim computation

### DIFF
--- a/gph/src/ripser.h
+++ b/gph/src/ripser.h
@@ -996,8 +996,11 @@ public:
 
             if (u != v) {
                 birth_vertex = dset.link_roots_and_get_birth_vertex(u, v);
-                // Elder rule; youngest class (max birth time of u and v)
-                // dies first
+                /* Unlike Ripser/ripser, here we do not exclude edges with
+                 * zero "diameters". This is because we don't assume that
+                 * all vertex weights are zero, as Ripser/ripser does. */
+                /* Elder rule; youngest class (max birth time of u and v)
+                 * dies first */
                 birth = birth_vertex.first;
                 value_t death = get_diameter(e);
                 if (death > birth) {

--- a/gph/src/ripser.h
+++ b/gph/src/ripser.h
@@ -967,8 +967,8 @@ public:
     void compute_dim_0_pairs(std::vector<diameter_index_t>& edges,
                              std::vector<diameter_index_t>& columns_to_reduce)
     {
-        // TODO: Get correct birth times if the edges are negative (required for
-        // lower star)
+        /* TODO: Ensure https://github.com/scikit-tda/ripser.py/issues/135 is no
+         * longer an issue for us. */
         union_find dset(n);
         for (index_t i = 0; i < n; i++) {
             dset.set_birth(i, get_vertex_birth(i));
@@ -995,26 +995,22 @@ public:
             index_t u = dset.find(v1), v = dset.find(v2);
 
             if (u != v) {
-                // link must be always done and now because we retrieve
-                // birth vertex value and index, it must be computed before
-                // the if condition
                 birth_vertex = dset.link_roots_and_get_birth_vertex(u, v);
-                if (get_diameter(e) != 0) {
-                    // Elder rule; youngest class (max birth time of u and v)
-                    // dies first
-                    birth = birth_vertex.first;
-                    value_t death = get_diameter(e);
-                    if (death > birth) {
-                        births_and_deaths_by_dim[0].push_back(birth);
-                        births_and_deaths_by_dim[0].push_back(death);
+                // Elder rule; youngest class (max birth time of u and v)
+                // dies first
+                birth = birth_vertex.first;
+                value_t death = get_diameter(e);
+                if (death > birth) {
+                    births_and_deaths_by_dim[0].push_back(birth);
+                    births_and_deaths_by_dim[0].push_back(death);
 
-                        if (return_flag_persistence_generators) {
-                            flag_persistence_generators.finite_0.push_back(
-                                {birth_vertex.second, std::max(v1, v2),
-                                 std::min(v1, v2)});
-                        }
+                    if (return_flag_persistence_generators) {
+                        flag_persistence_generators.finite_0.push_back(
+                            {birth_vertex.second, std::max(v1, v2),
+                             std::min(v1, v2)});
                     }
                 }
+
             } else if (prepare_higher_dims &&
                        get_index(get_zero_apparent_cofacet(e, 1)) == -1)
                 columns_to_reduce[i++] = e;

--- a/gph/src/ripser.h
+++ b/gph/src/ripser.h
@@ -986,7 +986,7 @@ public:
         columns_to_reduce.resize(edges.size());
         size_t i = 0;
         const bool prepare_higher_dims = (dim_max > 0);
-        value_t birth;
+        value_t birth, death;
         diameter_index_t birth_vertex;
         for (auto e : edges) {
             get_simplex_vertices(get_index(e), 1, n, vertices_of_edge.rbegin());
@@ -1002,7 +1002,7 @@ public:
                 /* Elder rule; youngest class (max birth time of u and v)
                  * dies first */
                 birth = birth_vertex.first;
-                value_t death = get_diameter(e);
+                death = get_diameter(e);
                 if (death > birth) {
                     births_and_deaths_by_dim[0].push_back(birth);
                     births_and_deaths_by_dim[0].push_back(death);
@@ -1013,7 +1013,6 @@ public:
                              std::min(v1, v2)});
                     }
                 }
-
             } else if (prepare_higher_dims &&
                        get_index(get_zero_apparent_cofacet(e, 1)) == -1)
                 columns_to_reduce[i++] = e;


### PR DESCRIPTION
Fixes #31, adding a unit test for "equivariance" (the property I was checking for in the example in #31) which fails in `main` but not after the fix.

New version of #41.