### PR TITLE
[CI] Add Python version 3.10, make sure pip and setuptools are upgraded during the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptool
+          python -m pip install --upgrade pip setuptools
           # The --upgrade and --upgrade-strategy eager flags ensure that pip will always install the latest allowed version of all the dependencies.
           python -m pip install --upgrade --upgrade-strategy eager -r requirements.txt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             # TODO: When updating c++ backend, use new date (yy-mm-dd)
           key: ${{ runner.os }}-ccache-${{ matrix.python-version }}-21-11-08
 
-      - name: Install dependencies
+      - name: Upgrade pip and setuptools
         run: |
           python -m pip install --upgrade pip setuptools
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip
@@ -62,11 +62,12 @@ jobs:
         continue-on-error: true
         with:
           path: ${{ matrix.path_ccache }}
-            # TODO: When updating c++ backend, use new date
-          key: ${{ runner.os }}-ccache-${{ matrix.python-version }}-21-02-12
+            # TODO: When updating c++ backend, use new date (yy-mm-dd)
+          key: ${{ runner.os }}-ccache-${{ matrix.python-version }}-21-11-08
 
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip setuptool
           # The --upgrade and --upgrade-strategy eager flags ensure that pip will always install the latest allowed version of all the dependencies.
           python -m pip install --upgrade --upgrade-strategy eager -r requirements.txt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          # The --upgrade and --upgrade-strategy eager flags ensure that pip will always install the latest allowed version of all the dependencies.
-          python -m pip install --upgrade --upgrade-strategy eager -r requirements.txt
 
       - name: Build giotto-ph on Linux and MacOs
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
           # Skip 32 bit architectures
           CIBW_SKIP: "*-win32 *-manylinux_i686"
           CIBW_BEFORE_BUILD: python -m pip install cmake

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,6 +27,7 @@ jobs:
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
           CIBW_TEST_REQUIRES: pytest hypothesis
 
+      # SciPy do not ship manylinux2010 wheels for Python 3.10, so we too build ours for manylinux2014
       - name: Build wheels for Python 3.10
         uses: pypa/cibuildwheel@v2.2.2
         env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,12 +20,22 @@ jobs:
         env:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
+          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
           # Skip 32 bit architectures, musllinux, and i686
           CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686"
           CIBW_BEFORE_BUILD: python -m pip install cmake
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
           CIBW_TEST_REQUIRES: pytest hypothesis
+
+      - name: Build wheels for Python 3.10
+        uses: pypa/cibuildwheel@v2.2.2
+        env:
+          CIBW_BUILD: "cp310-*"
+          CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686"
+          CIBW_BEFORE_BUILD: python -m pip install cmake
+          CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
+          CIBW_TEST_REQUIRES: pytest hypothesis
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
       - uses: actions/upload-artifact@v2
         name: Upload wheels


### PR DESCRIPTION
Partially addresses #45, and ensures `pip` and `setuptools` are updated.  This is important as e.g. the correct installation of our dependencies depends on having these packages up-to-date (we similarly upgrade in `giotto-tda` and `pyflagser`).