### PR TITLE
[CI] Fix wheels after issues with pip version

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,8 +18,10 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
 
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.2.2
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.2.2
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           # Specify which Python versions to build wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,17 +18,14 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.2.2
-
       - name: Build wheels
+        uses: pypa/cibuildwheel@v2.2.2
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
           CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
-          # Skip 32 bit architectures
-          # Skip Python 3.6 and 3.7 on Linux because we use here manylinux2014
+          # Skip 32 bit architectures, musllinux, and i686
           CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686"
           CIBW_BEFORE_BUILD: python -m pip install cmake
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,7 +28,19 @@ jobs:
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
           CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
           # Skip 32 bit architectures
-          CIBW_SKIP: "*-win32 *-manylinux_i686"
+          # Skip Python 3.6 and 3.7 on Linux because we use here manylinux2014
+          CIBW_SKIP: "*-win32 *-manylinux_i686 cp36-manylinux_x86_64 cp37-manylinux_x86_64"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_BEFORE_BUILD: python -m pip install cmake
+          CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
+          CIBW_TEST_REQUIRES: pytest hypothesis
+
+      - name: Build wheels Python 3.6 and 3.7 using manylinux2010
+        if: ${{ runner.os == 'Linux'}}
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp36-manylinux_x86_64 cp37-manylinux_x86_64"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
           CIBW_BEFORE_BUILD: python -m pip install cmake
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
           CIBW_TEST_REQUIRES: pytest hypothesis

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
           CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
           # Skip 32 bit architectures
           # Skip Python 3.6 and 3.7 on Linux because we use here manylinux2014
-          CIBW_SKIP: "*-win32 *-manylinux_i686 cp36-manylinux_x86_64 cp37-manylinux_x86_64"
+          CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686 cp36-manylinux_x86_64 cp37-manylinux_x86_64"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BEFORE_BUILD: python -m pip install cmake
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,7 +19,7 @@ jobs:
         name: Install Python
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.7.4
+        run: python -m pip install cibuildwheel==2.2.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,14 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2
-        name: Install Python
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.2.2
-
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.2.2
         env:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,18 +29,7 @@ jobs:
           CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
           # Skip 32 bit architectures
           # Skip Python 3.6 and 3.7 on Linux because we use here manylinux2014
-          CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686 cp36-manylinux_x86_64 cp37-manylinux_x86_64"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_BUILD: python -m pip install cmake
-          CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
-          CIBW_TEST_REQUIRES: pytest hypothesis
-
-      - name: Build wheels Python 3.6 and 3.7 using manylinux2010
-        if: ${{ runner.os == 'Linux'}}
-        run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_BUILD: "cp36-manylinux_x86_64 cp37-manylinux_x86_64"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
+          CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686"
           CIBW_BEFORE_BUILD: python -m pip install cmake
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
           CIBW_TEST_REQUIRES: pytest hypothesis


### PR DESCRIPTION
This PR fix the latest issues we encountered when trying to build the wheels.

The issue that was happening was due to on Python3.8, with the version of pip, it tried to compiles from sources scipy library (not expected behavior).
After debugging, we found out that updating the version of `cibuildwheels` this is now resolved.

## Work done

* [x] : Update `cibuildwheels` to v2.2.2
* [x] : Use `cibuildwheels` Github action now that it is available
* [x] : Disable `musllinux` wheels generation because they currently fail