### PR TITLE
Add information about Python 3.10 being supported

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -7,7 +7,7 @@ Major Features and Improvements
 -------------------------------
 
 - ``ripser_parallel`` can now return "flag persistence generators", i.e. vertices and edges creating/destroying bars in the barcode (`#29 <https://github.com/giotto-ai/giotto-ph/pull/29>`_). A new Jupyter notebook illustrates usage of this new feature.
-- Wheels for Python 3.10 have been added (`#49 <https://github.com/giotto-ai/giotto-ph/pull/49>`_).
+- Wheels for Python 3.10 have been added (`#47 <https://github.com/giotto-ai/giotto-ph/pull/47>`_).
 - The computation of the enclosing radius has been sped up (`#28 <https://github.com/giotto-ai/giotto-ph/pull/28>`_).
 - ``ripser_parallel`` can now be imported directly from ``gph`` (`#36 <https://github.com/giotto-ai/giotto-ph/pull/36>`_).
 - A garbage collection step which was found to negatively impact runtimes with little memory benefit has been removed (`#33 <https://github.com/giotto-ai/giotto-ph/pull/33>`_).

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -7,6 +7,7 @@ Major Features and Improvements
 -------------------------------
 
 - ``ripser_parallel`` can now return "flag persistence generators", i.e. vertices and edges creating/destroying bars in the barcode (`#29 <https://github.com/giotto-ai/giotto-ph/pull/29>`_). A new Jupyter notebook illustrates usage of this new feature.
+- Wheels for Python 3.10 have been added (`#48 <https://github.com/giotto-ai/giotto-ph/pull/48>`_).
 - The computation of the enclosing radius has been sped up (`#28 <https://github.com/giotto-ai/giotto-ph/pull/28>`_).
 - ``ripser_parallel`` can now be imported directly from ``gph`` (`#36 <https://github.com/giotto-ai/giotto-ph/pull/36>`_).
 - A garbage collection step which was found to negatively impact runtimes with little memory benefit has been removed (`#33 <https://github.com/giotto-ai/giotto-ph/pull/33>`_).

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -7,7 +7,7 @@ Major Features and Improvements
 -------------------------------
 
 - ``ripser_parallel`` can now return "flag persistence generators", i.e. vertices and edges creating/destroying bars in the barcode (`#29 <https://github.com/giotto-ai/giotto-ph/pull/29>`_). A new Jupyter notebook illustrates usage of this new feature.
-- Wheels for Python 3.10 have been added (`#48 <https://github.com/giotto-ai/giotto-ph/pull/48>`_).
+- Wheels for Python 3.10 have been added (`#49 <https://github.com/giotto-ai/giotto-ph/pull/49>`_).
 - The computation of the enclosing radius has been sped up (`#28 <https://github.com/giotto-ai/giotto-ph/pull/28>`_).
 - ``ripser_parallel`` can now be imported directly from ``gph`` (`#36 <https://github.com/giotto-ai/giotto-ph/pull/36>`_).
 - A garbage collection step which was found to negatively impact runtimes with little memory benefit has been removed (`#33 <https://github.com/giotto-ai/giotto-ph/pull/33>`_).

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ CLASSIFIERS = ["Intended Audience :: Science/Research",
                "Programming Language :: Python :: 3.6",
                "Programming Language :: Python :: 3.7",
                "Programming Language :: Python :: 3.8",
-               "Programming Language :: Python :: 3.9"]
+               "Programming Language :: Python :: 3.9",
+               "Programming Language :: Python :: 3.10"]
 KEYWORDS = "machine learning, topological data analysis, persistent " \
            "homology"
 INSTALL_REQUIRES = requirements


### PR DESCRIPTION
PR created pre-emptively under the assumptions that:
1. #47 gets merged
2. The wheel building is successful for Python 3.10.