### PR TITLE
[CPP] Avoid unnecessary binary search when k = 1 (0-simplices)

### DIFF
--- a/gph/src/ripser.h
+++ b/gph/src/ripser.h
@@ -706,11 +706,13 @@ public:
                                         index_t n, OutputIterator out) const
     {
         --n;
-        for (index_t k = dim + 1; k > 0; --k) {
+        for (index_t k = dim + 1; k > 1; --k) {
             n = get_max_vertex(idx, k, n);
             *out++ = n;
             idx -= binomial_coeff(n, k);
         }
+        // k = 1 is 0-simplices (vertices), and get_max_vertex(idx, 1, n) = idx
+        *out = idx;
         return out;
     }
 


### PR DESCRIPTION
Since `k = 1` corresponds to 0-simplices, and by Lemma 4.1. in the [Ripser paper](https://arxiv.org/pdf/1908.02518.pdf), one has that `get_max_vertex(idx, 1, n) = max{i | (i choose 1} ≤ idx} = idx` and we do not need to perform any binary search.

This has a very non-trivial impact on performance: every  time `get_simplex_vertices` is called (for any homology dimension), we end up calling `get_max_vertex(idx, 1, n)` and this binary search takes just as long as any of the others.

The fix here was already implemented in #38 but only by accident.  I did not know how significant it was.  In fact I wonder if it might explain *most* of the performance gains introduced by that PR (?). For this reason I think this fix deserves to be merged before any other PR that attempts to go even further.