### PR TITLE
[PY] Compute sparse matrix when input is a point-cloud with a threshold applied

### DIFF
--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -464,7 +464,7 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
             if metric == 'euclidean':
                 p = 2
             elif metric == 'minkowski':
-                p = metric_params['p']
+                p = metric_params.get('p', 2)
 
             dm = _pc_to_sparse_dm_with_threshold(X, thresh, p)
         else:

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -267,16 +267,33 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
                     metric_params={}, weights=None, weight_params=None,
                     collapse_edges=False, n_threads=1,
                     return_generators=False):
-    """Compute persistence diagrams for X data array.
+    """Compute persistence diagrams from an input dense array or sparse matrix.
 
-    If X is a point cloud, it will be converted to a distance matrix
-    using the chosen metric.
+    If `X` represents a point cloud, a distance matrix will be internally
+    created using the chosen metric and its Vietoris–Rips persistent homology
+    will be computed.
 
     Parameters
     ----------
-    X : ndarray of shape (n_samples, n_features)
-        A numpy array of either data or distance matrix. Can also be a sparse
-        distance matrix of type scipy.sparse
+    X : ndarray or sparse matrix
+        If `metric` is not set to ``"precomputed"``, input data of shape
+        ``(n_samples, n_features)`` representing a point cloud. Otherwise,
+        dense or sparse input data of shape ``(n_samples, n_samples)``
+        representing a distance matrix or adjacency matrix of a weighted
+        undirected graph, with the following conventions:
+            - Diagonal entries indicate vertex weights, i.e. the filtration
+              parameters at which vertices appear.
+            - If `X` is dense, only its upper diagonal portion (including the
+              diagonal) is considered.
+            - If `X` is sparse, it does not need to be upper diagonal or
+              symmetric. If only one of entry (i, j) and (j, i) is stored, its
+              value is taken as the weight of the undirected edge {i, j}. If
+              both are stored, the value in the upper diagonal is taken.
+              Off-diagonal entries which are not explicitly stored are treated
+              as infinite, indicating absent edges.
+            - Entries of `X` should be compatible with a filtration, i.e.
+              the value at index (i, j) should be no smaller than the
+              values at diagonal indices (i, i) and (j, j).
 
     maxdim : int, optional, default: ``1``
         Maximum homology dimension computed. Will compute all dimensions lower

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -249,7 +249,7 @@ def _ideal_thresh(dm, thresh):
     return min([enclosing_radius, thresh])
 
 
-def _pc_to_sparse_dm_with_threshold(X, thresh, algorithm, leaf_size,
+def _pc_to_sparse_dm_with_threshold(X, thresh, nearest_neighbors_params,
                                     metric, metric_params, n_threads):
     """Compute a sparse matrix of pairwise distances between points in a point
     cloud, removing all distances larger than a threshold.
@@ -257,11 +257,10 @@ def _pc_to_sparse_dm_with_threshold(X, thresh, algorithm, leaf_size,
     Return the output as an upper triangular sparse matrix in CSR format."""
 
     neigh = NearestNeighbors(radius=thresh,
-                             algorithm=algorithm,
-                             leaf_size=leaf_size,
                              metric=metric,
                              metric_params=metric_params,
-                             n_jobs=n_threads).fit(X)
+                             n_jobs=n_threads,
+                             **nearest_neighbors_params).fit(X)
     # Upper triangular CSR output
     dm = triu(neigh.radius_neighbors_graph(mode="distance"))
 
@@ -482,10 +481,9 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
     if metric == 'precomputed':
         dm = X
     elif thresh != np.inf:
-        algorithm = nearest_neighbors_params.get("algorithm", "auto")
-        leaf_size = nearest_neighbors_params.get("leaf_size", 30)
         dm = _pc_to_sparse_dm_with_threshold(
-            X, thresh, algorithm, leaf_size, metric, metric_params, n_threads
+            X, thresh, nearest_neighbors_params, metric, metric_params,
+            n_threads
             )
         is_dm_sparse_and_upper_triangular = True
     else:

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -459,7 +459,8 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
     if metric == 'precomputed':
         dm = X
     else:
-        if thresh != np.inf and metric in ['euclidean', 'minkowski']:
+        if not issparse(X) and thresh != np.inf and \
+                metric in ['euclidean', 'minkowski']:
             if metric == 'euclidean':
                 p = 2
             elif metric == 'minkowski':

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -470,7 +470,8 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
             "`collapse_edges` and `return_generators`cannot both be True."
         )
 
-    is_sparse_matrix_symmetric = None
+    use_sparse_computer = True
+    is_dm_sparse_and_symmetric = False
     if metric == 'precomputed':
         dm = X
     else:
@@ -482,18 +483,17 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
                 p = metric_params.get('p', 2)
 
             dm = _pc_to_sparse_dm_with_threshold(X, thresh, p)
-            is_sparse_matrix_symmetric = True
+            is_dm_sparse_and_symmetric = True
         else:
             dm = pairwise_distances(X, metric=metric, **metric_params)
 
     n_points = max(dm.shape)
 
-    use_sparse_computer = True
     if issparse(dm):
         coo = dm.tocoo()
         row, col, data = _sanitize_coo(
             coo.row, coo.col, coo.data,
-            only_extract_upper=is_sparse_matrix_symmetric
+            only_extract_upper=is_dm_sparse_and_symmetric
             )
 
         if weights is not None:

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -304,8 +304,10 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
         than or equal to this value.
 
     thresh : float, optional, default: ``numpy.inf``
-        Maximum distances considered when constructing filtration. If
-        ``numpy.inf``, compute the entire filtration.
+        Maximum value of the Vietoris–Rips filtration parameter. Points whose
+        distance is greater than this value will never be connected by an edge.
+        If ``numpy.inf``, compute the entire filtration. Otherwise, and if
+        `metric` is not ``"precomputed"``, see `nearest_neighbors_params`.
 
     coeff : int prime, optional, default: ``2``
         Compute homology with coefficients in the prime field Z/pZ for p=coeff.

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -466,7 +466,7 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
             elif metric == 'minkowski':
                 p = metric_params['p']
 
-            dm = _pc_to_dm_with_threshold(X, thresh, p)
+            dm = _pc_to_sparse_dm_with_threshold(X, thresh, p)
         else:
             dm = pairwise_distances(X, metric=metric, **metric_params)
 

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -197,7 +197,6 @@ def _compute_weights(dm, weights, weight_params, n_points,
         weights_r = weight_params.get("r", 2)
 
         if is_sparse:
-
             # Restrict to off-diagonal entries for weights computation since
             # diagonal ones are given by `weights`. Explicitly set the diagonal
             # to 0 -- this is also important for DTM since otherwise
@@ -235,12 +234,12 @@ def _compute_weights(dm, weights, weight_params, n_points,
 
 
 def _ideal_thresh(dm, thresh):
-    """This function computes enclosing radius. Enclosing radius
-    indicates that all distances above this threshold will produce
-    trivial homology
+    """Compute the enclosing radius of an input distance matrix.
 
-    Enclosing radius is only computed if input matrix is square
-    """
+    Under a Vietoris–Rips filtration, all homology groups are trivial above
+    this value because the complex becomes a cone.
+
+    The enclosing radius is only computed if the input matrix is square."""
 
     # Check that matrix is square
     if dm.shape[0] != dm.shape[1]:
@@ -253,11 +252,11 @@ def _ideal_thresh(dm, thresh):
 
 
 def _pc_to_sparse_dm_with_threshold(pc, thresh, p):
-    """This function computes a pairwise distance of a point cloud
-    but it uses a threshold to remove all values superior to this
-    threshold.
+    """Compute a sparse matrix of pairwise distances between points in a point
+    cloud, removing all distances larger than a threshold.
 
-    The output of this function is a coo_matrix"""
+    Return the output in COO format."""
+
     kd_tree = cKDTree(pc)
     return kd_tree.sparse_distance_matrix(kd_tree, thresh, p=p,
                                           output_type='coo_matrix')

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -527,7 +527,7 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
 
         if nonzero_in_diag:
             # Convert to sparse format, because currently that's the only one
-            # one handling nonzero births
+            # handling nonzero births
             (row, col) = np.triu_indices_from(dm)
             data = dm[(row, col)]
             if collapse_edges:
@@ -537,8 +537,8 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
                 flag_complex_collapse_edges_dense(dm.astype(np.float32),
                                                   thresh)
         elif not compute_enclosing_radius:
-            # If the user specifies a threshold, we use a sparse
-            # representation like Ripser does
+            # If the user specifies a threshold, we use a sparse representation
+            # like Ripser does
             row, col = np.nonzero(dm <= thresh)
             data = dm[(row, col)]
             row, col, data = _sanitize_coo(row, col, data,

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -252,7 +252,7 @@ def _ideal_thresh(dm, thresh):
     return min([enclosing_radius, thresh])
 
 
-def _pc_to_dm_with_threshold(pc, thresh, p):
+def _pc_to_sparse_dm_with_threshold(pc, thresh, p):
     """This function computes a pairwise distance of a point cloud
     but it uses a threshold to remove all values superior to this
     threshold.

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -325,6 +325,21 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
     metric_params : dict, optional, default: ``{}``
         Additional parameters to be passed to the distance function.
 
+    nearest_neighbors_params : dict, optional, default: ``{}``
+        Additional parameters that can be passed when `thresh` is finite and
+        `metric` is not ``"precomputed"``. Allowed keys and values are as
+        follows:
+
+            - ``"algorithm"``: ``"auto"`` | ``"ball_tree"`` | ``"kd_tree"`` |
+              ``"brute"`` (default when not passed: ``"auto"``)
+            - ``"leaf_size"``: int (default when not passed: ``30``)
+
+        These are passed as keyword arguments to an instance of
+        :class:`sklearn.neighbors.NearestNeighbors` to compute the thresholded
+        distance matrix in a sparse format. See the relevant
+        `scikit-learn User Guide
+        <https://scikit-learn.org/stable/modules/neighbors.html>`_.
+
     weights : ``"DTM"``, ndarray or None, optional, default: ``None``
         If not ``None``, the persistence of a weighted Vietoris-Rips filtration
         is computed as described in [6]_, and this parameter determines the

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -258,15 +258,16 @@ def _pc_to_sparse_dm_with_threshold(X, thresh, nearest_neighbors_params,
     """Compute a sparse matrix of pairwise distances between points in a point
     cloud, removing all distances larger than a threshold.
 
-    Return the output as an upper triangular sparse matrix in CSR format."""
+    Return the output as an upper triangular sparse matrix in COO format."""
 
     neigh = NearestNeighbors(radius=thresh,
                              metric=metric,
                              metric_params=metric_params,
                              n_jobs=n_threads,
                              **nearest_neighbors_params).fit(X)
-    # Upper triangular CSR output
-    dm = triu(neigh.radius_neighbors_graph(mode="distance"))
+    # Upper triangular COO output
+    dm = triu(neigh.radius_neighbors_graph(mode="distance"),
+              format="coo")
 
     return dm
 

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -253,6 +253,11 @@ def _ideal_thresh(dm, thresh):
 
 
 def _pc_to_dm_with_threshold(pc, thresh, p):
+    """This function computes a pairwise distance of a point cloud
+    but it uses a threshold to remove all values superior to this
+    threshold.
+
+    The output of this function is a coo_matrix"""
     kd_tree = cKDTree(pc)
     return kd_tree.sparse_distance_matrix(kd_tree, thresh, p=p,
                                           output_type='coo_matrix')

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -261,7 +261,7 @@ def _pc_to_sparse_dm_with_threshold(X, thresh, algorithm, leaf_size,
                              leaf_size=leaf_size,
                              metric=metric,
                              metric_params=metric_params,
-                             n_jobs=n_jobs).fit(X)
+                             n_jobs=n_threads).fit(X)
     # Upper triangular CSR output
     dm = triu(neigh.radius_neighbors_graph(mode="distance"))
 

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -31,6 +31,9 @@ from sklearn.utils.validation import column_or_1d
 from ..modules import gph_ripser, gph_ripser_coeff, gph_collapser
 
 
+MAX_COEFF_SUPPORTED = gph_ripser.get_max_coefficient_field_supported()
+
+
 def _compute_ph_vr_dense(DParam, maxHomDim, thresh=-1, coeff=2, n_threads=1,
                          return_generators=False):
     if coeff == 2:
@@ -509,11 +512,10 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
             "`collapse_edges` and `return_generators`cannot both be True."
         )
 
-    max_coeff_supported = gph_ripser.get_max_coefficient_field_supported()
     if coeff != 2 and \
-            not _is_prime_and_larger_than_2(coeff, max_coeff_supported):
+            not _is_prime_and_larger_than_2(coeff, MAX_COEFF_SUPPORTED):
         raise ValueError("coeff value not supported, coeff value must be prime"
-                         " and lower than {}".format(max_coeff_supported))
+                         " and lower than {}".format(MAX_COEFF_SUPPORTED))
 
     use_sparse_computer = True
     is_dm_sparse_and_upper_triangular = False

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -291,9 +291,9 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
               both are stored, the value in the upper diagonal is taken.
               Off-diagonal entries which are not explicitly stored are treated
               as infinite, indicating absent edges.
-            - Entries of `X` should be compatible with a filtration, i.e.
-              the value at index (i, j) should be no smaller than the
-              values at diagonal indices (i, i) and (j, j).
+            - Entries of `X` should be compatible with a filtration, i.e. the
+              the value at index (i, j) should be no smaller than the values at
+              diagonal indices (i, i) and (j, j).
 
     maxdim : int, optional, default: ``1``
         Maximum homology dimension computed. Will compute all dimensions lower
@@ -312,11 +312,10 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
         as a distance matrix or of adjacency matrices of a weighted undirected
         graph. If a string, it must be one of the options allowed by
         :func:`scipy.spatial.distance.pdist` for its metric parameter, or a
-        or a metric listed in
-        :obj:`sklearn.pairwise.PAIRWISE_DISTANCE_FUNCTIONS`, including
-        ``'euclidean'``, ``'manhattan'`` or ``'cosine'``. If a callable, it
-        should take pairs of vectors (1D arrays) as input and, for each two
-        vectors in a pair, it should return a scalar indicating the
+        metric listed in :obj:`sklearn.pairwise.PAIRWISE_DISTANCE_FUNCTIONS`,
+        including ``'euclidean'``, ``'manhattan'`` or ``'cosine'``. If a
+        callable, it should take pairs of vectors (1D arrays) as input and, for
+        each two vectors in a pair, it should return a scalar indicating the
         distance/dissimilarity between them.
 
     metric_params : dict, optional, default: ``{}``

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -252,9 +252,9 @@ def _ideal_thresh(dm, thresh):
     return min([enclosing_radius, thresh])
 
 
-def _pc_to_dm_with_threshold(pc, thresh, metric="euclidean"):
+def _pc_to_dm_with_threshold(pc, thresh, p):
     kd_tree = cKDTree(pc)
-    return kd_tree.sparse_distance_matrix(kd_tree, thresh,
+    return kd_tree.sparse_distance_matrix(kd_tree, thresh, p=p,
                                           output_type='coo_matrix')
 
 
@@ -454,8 +454,13 @@ def ripser_parallel(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
     if metric == 'precomputed':
         dm = X
     else:
-        if thresh != np.inf:
-            dm = _pc_to_dm_with_threshold(X, thresh, metric)
+        if thresh != np.inf and metric in ['euclidean', 'minkowski']:
+            if metric == 'euclidean':
+                p = 2
+            elif metric == 'minkowski':
+                p = metric_params['p']
+
+            dm = _pc_to_dm_with_threshold(X, thresh, p)
         else:
             dm = pairwise_distances(X, metric=metric, **metric_params)
 

--- a/gph/python/test/test_ripser.py
+++ b/gph/python/test/test_ripser.py
@@ -385,3 +385,19 @@ def test_equivariance_regression():
         dgms_offset = ripser(dm - offset, **kwargs)["dgms"]
         for dim in range(maxdim + 1):
             assert_array_equal(dgms_offset[dim], dgms_orig[dim] - offset)
+
+
+def test_optimized_distance_matrix():
+    """Ensure that using the optimized distance matrix computation when using
+    threshold produces the same results than using one with a threshold who
+    correspond to the enclosing radius.
+    """
+    X = np.random.default_rng(0).random((100, 3))
+    maxdim = 2
+    enclosing_radius = 0.8884447324918705
+
+    dgms = ripser(X, maxdim=maxdim)["dgms"]
+    dgms_thresh = ripser(X, maxdim=maxdim, thresh=enclosing_radius)["dgms"]
+
+    for dim, dgm in enumerate(dgms):
+        assert_array_equal(dgm, dgms_thresh[dim])

--- a/gph/python/test/test_ripser.py
+++ b/gph/python/test/test_ripser.py
@@ -403,3 +403,16 @@ def test_optimized_distance_matrix(metric):
 
     for dim, dgm in enumerate(dgms):
         assert_array_equal(dgm, dgms_thresh[dim])
+
+
+def test_dense_finite_thresh_zero_edges():
+    """Check that if a dense distance matrix and a finite threshold are passed,
+    and some edges are zero, these edges are not treated as absent. Serves as
+    a regression test for issue #55."""
+    dm = np.array([[0., 0.],
+                   [0., 0.]])
+    dgm_0 = ripser(dm)["dgms"][0]
+    dgm_0_finite_thresh = ripser(dm, thresh=1.)["dgms"][0]
+    dgm_0_exp = np.array([[0., np.inf]])
+    assert_array_equal(dgm_0, dgm_0_exp)
+    assert_array_equal(dgm_0_finite_thresh, dgm_0_exp)

--- a/gph/python/test/test_ripser.py
+++ b/gph/python/test/test_ripser.py
@@ -387,8 +387,7 @@ def test_equivariance_regression():
             assert_array_equal(dgms_offset[dim], dgms_orig[dim] - offset)
 
 
-@pytest.mark.parametrize('metric', ['euclidean', 'minkowski'])
-def test_optimized_distance_matrix(metric):
+def test_optimized_distance_matrix():
     """Ensure that using the optimized distance matrix computation when using
     threshold produces the same results than using one with a threshold who
     correspond to the enclosing radius.
@@ -397,9 +396,8 @@ def test_optimized_distance_matrix(metric):
     maxdim = 2
     enclosing_radius = 0.8884447324918705
 
-    dgms = ripser(X, metric=metric,  maxdim=maxdim)["dgms"]
-    dgms_thresh = ripser(X, metric=metric, maxdim=maxdim,
-                         thresh=enclosing_radius)["dgms"]
+    dgms = ripser(X,  maxdim=maxdim)["dgms"]
+    dgms_thresh = ripser(X, maxdim=maxdim, thresh=enclosing_radius)["dgms"]
 
     for dim, dgm in enumerate(dgms):
         assert_array_equal(dgm, dgms_thresh[dim])

--- a/gph/python/test/test_ripser.py
+++ b/gph/python/test/test_ripser.py
@@ -396,7 +396,7 @@ def test_optimized_distance_matrix():
     maxdim = 2
     enclosing_radius = 0.8884447324918705
 
-    dgms = ripser(X,  maxdim=maxdim)["dgms"]
+    dgms = ripser(X, maxdim=maxdim)["dgms"]
     dgms_thresh = ripser(X, maxdim=maxdim, thresh=enclosing_radius)["dgms"]
 
     for dim, dgm in enumerate(dgms):

--- a/gph/python/test/test_ripser.py
+++ b/gph/python/test/test_ripser.py
@@ -387,7 +387,8 @@ def test_equivariance_regression():
             assert_array_equal(dgms_offset[dim], dgms_orig[dim] - offset)
 
 
-def test_optimized_distance_matrix():
+@pytest.mark.parametrize('metric', ['euclidean', 'minkowski'])
+def test_optimized_distance_matrix(metric):
     """Ensure that using the optimized distance matrix computation when using
     threshold produces the same results than using one with a threshold who
     correspond to the enclosing radius.
@@ -396,8 +397,9 @@ def test_optimized_distance_matrix():
     maxdim = 2
     enclosing_radius = 0.8884447324918705
 
-    dgms = ripser(X, maxdim=maxdim)["dgms"]
-    dgms_thresh = ripser(X, maxdim=maxdim, thresh=enclosing_radius)["dgms"]
+    dgms = ripser(X, metric=metric,  maxdim=maxdim)["dgms"]
+    dgms_thresh = ripser(X, metric=metric, maxdim=maxdim,
+                         thresh=enclosing_radius)["dgms"]
 
     for dim, dgm in enumerate(dgms):
         assert_array_equal(dgm, dgms_thresh[dim])


### PR DESCRIPTION
This PR adds an optimization for computing the distance matrix from a point cloud directly in Python.

We observed that the computation of a distance matrix for a big point cloud (50k points), is quite expensive.
The upstream C++ `ripser`, when passing a point-cloud with a threshold, computes directly a sparse distance matrix with all distances above the threshold removed.

We reproduce this behavior directly in Python by using a method from `scipy` library.

* [x] Implement the method in Python
    * [x] ~Support for `euclidean` metric~
    * [x] ~Support for `minkowski` metric~
    * [x] ~Support to any other metric ?~
    * [x] Use `sklearn` NearestNeighbors instead of `scipy` approach.
* [x] Add test that compares 2 run on the same dataset, with one using a threshold (enclosing radius) and the other with threshold.
    * [x] ~Test using `euclidean` metric~
    * [x] ~Test using `minkowski` metric~
* [x] Document this behavior somewhere ?
    * [x] : Rework the documentation of X as suggested by @ulupo 
* [x] Sanitize sparse input distance matrix
* [x] Fix #55 