### PR TITLE
Drop Python 3.6, enable Apple Silicon wheels for Python 3.8, 3.9 and 3.10, upgrade to manylinux2014

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.7, 3.8, 3.9, '3.10']
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,7 +27,7 @@ jobs:
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
           CIBW_TEST_REQUIRES: pytest hypothesis
           # Should generate universal2 wheels for CP3.8 and CP3.9
-          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+          CIBW_ARCHS_MACOS: universal2
 
       # SciPy do not ship manylinux2010 wheels for Python 3.10, so we too build ours for manylinux2014
       - name: Build wheels for Python 3.10
@@ -39,7 +39,7 @@ jobs:
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
           CIBW_TEST_REQUIRES: pytest hypothesis
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+          CIBW_ARCHS_MACOS: universal2
 
       - uses: actions/upload-artifact@v2
         name: Upload wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,25 +20,14 @@ jobs:
         env:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_BUILD: "cp37-* cp38-* cp39-*"
+          CIBW_BUILD: "cp37-* cp38-* cp39-*" "cp310-*" "cp311-*"
           # Skip 32 bit architectures, musllinux, and i686
           CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686"
           CIBW_BEFORE_BUILD: python -m pip install cmake
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
           CIBW_TEST_REQUIRES: pytest hypothesis
-          # Should generate universal2 wheels for CP3.8 and CP3.9
-          CIBW_ARCHS_MACOS: universal2
-
-      # SciPy do not ship manylinux2010 wheels for Python 3.10, so we too build ours for manylinux2014
-      - name: Build wheels for Python 3.10
-        uses: pypa/cibuildwheel@v2.3.1
-        env:
-          CIBW_BUILD: "cp310-*"
-          CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686"
-          CIBW_BEFORE_BUILD: python -m pip install cmake
-          CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
-          CIBW_TEST_REQUIRES: pytest hypothesis
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          # Should generate universal2 wheels for CP3.8 -- CP3.10
           CIBW_ARCHS_MACOS: universal2
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+          CIBW_BUILD: "cp37-* cp38-* cp39-*"
           # Skip 32 bit architectures, musllinux, and i686
           CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686"
           CIBW_BEFORE_BUILD: python -m pip install cmake

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_BUILD: "cp37-* cp38-* cp39-*" "cp310-*" "cp311-*"
+          CIBW_BUILD: "cp37-* cp38-* cp39-*" "cp310-*"
           # Skip 32 bit architectures, musllinux, and i686
           CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686"
           CIBW_BEFORE_BUILD: python -m pip install cmake

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,7 +27,7 @@ jobs:
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
           CIBW_TEST_REQUIRES: pytest hypothesis
           # Should generate universal2 wheels for CP3.8 and CP3.9
-          CIBW_ARCHS_MACOS: x86_64 universal2
+          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
 
       # SciPy do not ship manylinux2010 wheels for Python 3.10, so we too build ours for manylinux2014
       - name: Build wheels for Python 3.10
@@ -39,7 +39,7 @@ jobs:
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
           CIBW_TEST_REQUIRES: pytest hypothesis
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_ARCHS_MACOS: x86_64 universal2
+          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
 
       - uses: actions/upload-artifact@v2
         name: Upload wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.2.2
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
@@ -26,10 +26,12 @@ jobs:
           CIBW_BEFORE_BUILD: python -m pip install cmake
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
           CIBW_TEST_REQUIRES: pytest hypothesis
+          # Should generate universal2 wheels for CP3.8 and CP3.9
+          CIBW_ARCHS_MACOS: x86_64 universal2
 
       # SciPy do not ship manylinux2010 wheels for Python 3.10, so we too build ours for manylinux2014
       - name: Build wheels for Python 3.10
-        uses: pypa/cibuildwheel@v2.2.2
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BUILD: "cp310-*"
           CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686"
@@ -37,6 +39,7 @@ jobs:
           CIBW_TEST_COMMAND: python -m pytest {package}/gph/python/test
           CIBW_TEST_REQUIRES: pytest hypothesis
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_ARCHS_MACOS: x86_64 universal2
 
       - uses: actions/upload-artifact@v2
         name: Upload wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_BUILD: "cp37-* cp38-* cp39-*" "cp310-*"
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-*"
           # Skip 32 bit architectures, musllinux, and i686
           CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686"
           CIBW_BEFORE_BUILD: python -m pip install cmake

--- a/gph/python/ripser_interface.py
+++ b/gph/python/ripser_interface.py
@@ -18,7 +18,6 @@
 # SOFTWARE.
 
 import math
-import time
 from warnings import catch_warnings, simplefilter
 
 import numpy as np

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,10 @@ CLASSIFIERS = ["Intended Audience :: Science/Research",
                "Operating System :: POSIX",
                "Operating System :: Unix",
                "Operating System :: MacOS",
-               "Programming Language :: Python :: 3.6",
                "Programming Language :: Python :: 3.7",
                "Programming Language :: Python :: 3.8",
                "Programming Language :: Python :: 3.9",
+               "Programming Language :: Python :: 3.10",
                "Programming Language :: Python :: 3.10"]
 KEYWORDS = "machine learning, topological data analysis, persistent " \
            "homology"

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,13 @@ class CMakeBuild(build_ext):
             cmake_args += [f"-DCMAKE_BUILD_TYPE={cfg}"]
             build_args += ["--", "-j2"]
 
+        if sys.platform.startswith("darwin"):
+            # Cross-compile support for macOS - respect ARCHFLAGS if set
+            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
+            if archs:
+                cmake_args += \
+                    ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
+
         env = os.environ.copy()
         env["CXXFLAGS"] = f"{env.get('CXXFLAGS', '')} -DVERSION_INFO="\
                           f"\\'{self.distribution.get_version()}\\'"

--- a/setup.py
+++ b/setup.py
@@ -129,11 +129,6 @@ class CMakeBuild(build_ext):
                 cmake_args += ["-A", "x64"]
             build_args += ["--", "/m"]
         else:
-            # ARCHFLAGS is always set by cibuildwheel before macOS wheel builds.
-            archflags = os.getenv("ARCHFLAGS", "")
-            if "arm64" in archflags:
-                cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
-
             cmake_args += [f"-DCMAKE_BUILD_TYPE={cfg}"]
             build_args += ["--", "-j2"]
 

--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,11 @@ class CMakeBuild(build_ext):
                 cmake_args += ["-A", "x64"]
             build_args += ["--", "/m"]
         else:
+            # ARCHFLAGS is always set by cibuildwheel before macOS wheel builds.
+            archflags = os.getenv("ARCHFLAGS", "")
+            if "arm64" in archflags:
+                cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
+
             cmake_args += [f"-DCMAKE_BUILD_TYPE={cfg}"]
             build_args += ["--", "-j2"]
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ CLASSIFIERS = ["Intended Audience :: Science/Research",
                "Programming Language :: Python :: 3.7",
                "Programming Language :: Python :: 3.8",
                "Programming Language :: Python :: 3.9",
-               "Programming Language :: Python :: 3.10",
                "Programming Language :: Python :: 3.10"]
 KEYWORDS = "machine learning, topological data analysis, persistent " \
            "homology"


### PR DESCRIPTION
This PR provide wheels for the new Apple Silicon for Python 3.8, 3.9 and 3.10.
Unfortunately, for the moment the wheels can be generated but cannot be tested because Github Action runner do not have a native ARM runner for MacOS.

I did not find if a public statement will provide in a near future support for native ARM runners. But on the meantime we can already generate the wheels and anybody that has a Mac with the new Silicon can perform the test on his/her machine and let us if it works. And only then, we will upload the new wheels on Pypi.

Unfortunately I do not have this kind of machine available.

Of course another option would be to emulate the hardware, but, for the moment I do not have the time to deploy this kind of feature.