### PR TITLE
pybind11 module updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-*"
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-*"
           # Skip 32 bit architectures, musllinux, i686, and macOS x86_64 wheels for CP3.8 -- CP3.10
           CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686 cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64"
           CIBW_BEFORE_BUILD: python -m pip install cmake


### PR DESCRIPTION
This update allows to install giotto-ph on Python 3.11 and below. The project only needed to update the pybind11 library.