### PR TITLE
Add support for building Python 3.11 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,13 +21,13 @@ jobs:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-*"
-          # Skip 32 bit architectures, musllinux, i686, and macOS x86_64 wheels for CP3.8 -- CP3.10
-          CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686 cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64"
+          # Skip 32 bit architectures, musllinux, i686, and macOS x86_64 wheels for CP3.8 -- CP3.11
+          CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686 cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64 cp311-macosx_x86_64"
           CIBW_BEFORE_BUILD: python -m pip install cmake
           CIBW_TEST_COMMAND: python -m pytest --pyargs gph
           CIBW_TEST_REQUIRES: pytest hypothesis
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          # Should generate universal2 wheels for CP3.8 -- CP3.10
+          # Should generate universal2 wheels for CP3.8 -- CP3.11
           CIBW_ARCHS_MACOS: x86_64 universal2
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Description:

 • Updated CIBW_BUILD to include cp311-* for Python 3.11.
 • Updated comments in wheels workflow